### PR TITLE
annotate-from-file-buildkite-plugin - Add catalog info file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: annotate-from-file-buildkite-plugin
+  description: Buildkite plugin for annotating builds from a file
+  annotations:
+    github.com/project-slug: https://github.com/blstrco/annotate-from-file-buildkite-plugin
+    backstage.io/techdocs-ref: dir:.
+spec:
+  type: Component
+  lifecycle: experimental
+  owner: "linktree"


### PR DESCRIPTION
Adds a basic catalog-info.yaml so it can be seen in backstage