### PR TITLE
annotate-from-file-buildkite-plugin - Add inital docs for backstage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,19 @@
+# annotate-from-file-buildkite-plugin
+
+A buildkite plugin that creates annotations from a given file path
+
+This documentation is built using [mkdocs](https://www.mkdocs.org/user-guide/) for [Backstage](https://backstage.io/docs/features/techdocs/techdocs-overview)
+
+
+## Using annotate-from-file-buildkite-plugin
+
+* Todo
+
+# Common tasks
+
+* Todo
+
+## Related Projects
+
+
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,12 @@
+site_name: "annotate-from-file-buildkite-plugin"
+site_description: "A buildkite plugin that creates annotations from a given file path"
+
+plugins:
+  - techdocs-core
+
+# ---
+#  With `nav` commented out mkdocs will genetrate a list of all the files in the docs folder automatically
+#  Uncomment it to overwrite this behaviors and build your own navigation tree
+# ---
+# nav:
+#   - Home: index.md


### PR DESCRIPTION
Adds a basic doc folder and config so they can be seen in backstage